### PR TITLE
Logging für KonsollenKommands via Chat + Hafen mit löschenden Angeboten möglich.

### DIFF
--- a/.github/workflows/CompleteQSBAction.yml
+++ b/.github/workflows/CompleteQSBAction.yml
@@ -87,7 +87,18 @@ jobs:
           echo " "
           echo Binaries Done
           echo ------------------------------------------------------------------
-      
+
+      - name: Cut Comments out
+        run: echo ------------------------------------------------------------------
+             echo Removing all Comments from QSB-output Files
+             echo " "
+             sed '/^--/d' qsb/lua/var/build/source/qsb.lua 
+             sed '/^--/d' qsb/lua/var/build/source/qsb_all.lua
+             sed '/^--/d' qsb/lua/var/build/source/qsb_comp.lua
+             echo Removing all Comments done
+             echo ------------------------------------------------------------------
+             
+
       - name: Setting ReleastTag
         run: echo "ReleaseTag=$(cat version.txt)" >> $GITHUB_ENV
           

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,9 @@
 
 # Changelog:
 
-- *change* loglevel der BCS Ausgabe wurde angepasst
-- *change* Wird ein Händler über die Kompatibilität aufgerufen werden die Angebote beim Ausfahren zurückgesetzt.
-- *fix* Formaler Fehler in FlyTo gefixt
-- *fix* Bei AP konnte die Duration zu einem Boolean werden
+- *change* Für das Logging der Konsolenkommandos wurde ein neues, manuelles Logging erstellt.
+- *change* Für das Setzen des Loglevels kann nun in `API.ActivateDebugMode`ein fünfter Parameter bei Bedarf optional gesetzt werden, mit dem das LogLevel manuell gesetzt wird.
+- *changeback* Wird ein Händler über die Kompatibilität aufgerufen werden die Angebote beim Ausfahren zurückgesetzt.
+- *change* Wird eine Tradedescription (Handelsbeschreibung) beim Hafen mit dem Wert "true" für "OldHarbour" gesetzt, werden Angebote mit verlassen des Schiffes gelöscht.
+- *change* Die Möglichkeit mit API.TravelingSalesmanShouting(_flag) die Nachrichten des Händlers zu visualieren wurde hinzugefügt. Standardwert für das Erhalten der Nachrichten ist true.
 

--- a/qsb/lua/modules/QSB_0_Kernel/debug.lua
+++ b/qsb/lua/modules/QSB_0_Kernel/debug.lua
@@ -334,10 +334,9 @@ end
 --
 function API.ActivateDebugMode(_CheckAtRun, _TraceQuests, _DevelopingCheats, _DevelopingShell, _LogLevel)
     Swift.Debug:ActivateDebugMode(_CheckAtRun, _TraceQuests, _DevelopingCheats, _DevelopingShell);
-    if _LogLevel == nil then
-        _LogLevel = 4
+    if _LogLevel then
+        API.SetLogLevel(_LogLevel, _LogLevel)
     end
-    API.SetLogLevel(_LogLevel, _LogLevel)
 end
 
 -- Aktiviert DisplayScriptErrors, auch wenn der Benutzer das Spiel nicht

--- a/qsb/lua/modules/QSB_0_Kernel/logging.lua
+++ b/qsb/lua/modules/QSB_0_Kernel/logging.lua
@@ -13,6 +13,7 @@ Swift.Logging = {
 };
 
 QSB.LogLevel = {
+    ManuelLogging = 5;
     ALL     = 4;
     INFO    = 3;
     WARNING = 2;
@@ -80,6 +81,9 @@ function warn(_Text, _Silent)
 end
 function error(_Text, _Silent)
     Swift.Logging:Log("ERROR: " .._Text, QSB.LogLevel.ERROR, not _Silent);
+end
+function manuelLogging(_text, _Silent)
+    Swift.Logging:Log("Log: " .._Text, QSB.LogLevel.ManuelLogging, not _Silent);
 end
 
 -- -------------------------------------------------------------------------- --

--- a/qsb/lua/modules/QSB_2_Quest/source.lua
+++ b/qsb/lua/modules/QSB_2_Quest/source.lua
@@ -618,34 +618,34 @@ function ModuleQuest.Global:ProcessChatInput(_Text, _PlayerID, _IsDebug)
             end
             if Commands[i][1] == "fail" then
                 API.FailQuest(FoundQuests[1]);
-                info("fail quest '" ..FoundQuests[1].. "'");
+                manuelLogging("fail quest '" ..FoundQuests[1].. "'");
             elseif Commands[i][1] == "restart" then
                 API.RestartQuest(FoundQuests[1]);
-                info("restart quest '" ..FoundQuests[1].. "'");
+                manuelLogging("restart quest '" ..FoundQuests[1].. "'");
             elseif Commands[i][1] == "start" then
                 API.StartQuest(FoundQuests[1]);
-                info("trigger quest '" ..FoundQuests[1].. "'");
+                manuelLogging("trigger quest '" ..FoundQuests[1].. "'");
             elseif Commands[i][1] == "stop" then
                 API.StopQuest(FoundQuests[1]);
-                info("interrupt quest '" ..FoundQuests[1].. "'");
+                manuelLogging("interrupt quest '" ..FoundQuests[1].. "'");
             elseif Commands[i][1] == "win" then
                 API.WinQuest(FoundQuests[1]);
-                info("win quest '" ..FoundQuests[1].. "'");
+                manuelLogging("win quest '" ..FoundQuests[1].. "'");
             end
         end
 
         if Commands[i][1] == "stopped" then
-            info( self:FindQuestsByState(QuestState.Interrupted) )
+            manuelLogging( self:FindQuestsByState(QuestState.Interrupted) )
         elseif Commands[i][1] == "active" then
-            info( self:FindQuestsByState(QuestState.Active) )
+            manuelLogging( self:FindQuestsByState(QuestState.Active) )
         elseif Commands[i][1] == "won" then
-            info( self:FindQuestsByState(QuestState.Success) )
+            manuelLogging( self:FindQuestsByState(QuestState.Success) )
         elseif Commands[i][1] == "failed" then
-            info( self:FindQuestsByState(QuestState.Failure) )
+            manuelLogging( self:FindQuestsByState(QuestState.Failure) )
         elseif Commands[i][1] == "waiting" then
-            info( self:FindQuestsByState(QuestState.NotTriggered) )
+            manuelLogging( self:FindQuestsByState(QuestState.NotTriggered) )
         elseif Commands[i][1] == "find" then
-            info( self:FindQuestsByNamePart(Commands[i]) )
+            manuelLogging( self:FindQuestsByNamePart(Commands[i]) )
         end
     end
 end

--- a/qsb/lua/modules/QSB_3_TradeRoutes/compatibility.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/compatibility.lua
@@ -31,8 +31,8 @@
 --     Interval   = 3,       -- Monate zwischen zwei Anfarten (Standard: 2)
 --     OfferCount = 4,       -- Anzahl Angebote (1 bis 4) (Standard: 4)
 --     NoIce      = true,    -- Schiff kommt nicht im Winter (Standard: false)
---     OldHarbor  = true     -- Optional, Angebote werden mit Verlassen des Schiffs wieder entfernt (Standard: false)
---     Name       = "Route1" -- Optional, Pro Hafen kann nur eine Route diesen Namen haben. Wird zum Entfernen und Verändern von Routen benutzt.
+--     OldHarbor  = true,     -- Optional, Angebote werden mit Verlassen des Schiffs wieder entfernt (Standard: false)
+--     Name       = "Route1", -- Optional, Pro Hafen kann nur eine Route diesen Namen haben. Wird zum Entfernen und Verändern von Routen benutzt.
 --     Offers = {
 --         -- Angebot, Menge
 --         {"G_Gems", 5},

--- a/qsb/lua/modules/QSB_3_TradeRoutes/compatibility.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/compatibility.lua
@@ -61,3 +61,15 @@ function API.TravelingSalesmanCreate(_TraderDescription)
     API.InitHarbor(_TraderDescription.PlayerID, _TraderDescription)
 end
 TravelingSalesmanCreate = API.TravelingSalesmanCreate;
+
+-- Setzt ob der Händler des Hafens etwas sagen soll, nachdem er etwas gemacht hat bzw. passiert ist.
+--
+--<b>QSB:</b> API.InitHarbor(_PlayerID, ...)
+--@param[type=boolean] _flag true oder false. Standartwert ist true
+--@within QSB_3_TradeRoutes
+--
+--@usage API.TravelingSalesmanShouting(true)
+--@usage API.TravelingSalesmanShouting(false)
+function API.TravelingSalesmanShouting(_flag)
+    ModuleShipSalesment.Global.LoudTrader = _flag;
+end

--- a/qsb/lua/modules/QSB_3_TradeRoutes/compatibility.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/compatibility.lua
@@ -31,6 +31,8 @@
 --     Interval   = 3,       -- Monate zwischen zwei Anfarten (Standard: 2)
 --     OfferCount = 4,       -- Anzahl Angebote (1 bis 4) (Standard: 4)
 --     NoIce      = true,    -- Schiff kommt nicht im Winter (Standard: false)
+--     OldHarbor  = true     -- Optional, Angebote werden mit Verlassen des Schiffs wieder entfernt (Standard: false)
+--     Name       = "Route1" -- Optional, Pro Hafen kann nur eine Route diesen Namen haben. Wird zum Entfernen und Verändern von Routen benutzt.
 --     Offers = {
 --         -- Angebot, Menge
 --         {"G_Gems", 5},
@@ -53,7 +55,6 @@ function API.TravelingSalesmanCreate(_TraderDescription)
     if GUI then
         return;
     end
-    ModuleShipSalesment.Global.Conmpatibility = true
     _TraderDescription.Name = "TravelingSalesman" .. _TraderDescription.PlayerID
     _TraderDescription.Interval = _TraderDescription.Interval * 60
     _TraderDescription.Amount = _TraderDescription.OfferCount

--- a/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
@@ -39,7 +39,7 @@ end
 function ModuleShipSalesment.Global:OnEvent(_ID, ...)
     if _ID == QSB.ScriptEvents.LoadscreenClosed then
         self.LoadscreenClosed = true;
-    else _ID == QSB.ScriptEvents.TradeShipLeft then
+    elseif  _ID == QSB.ScriptEvents.TradeShipLeft then
         for _index = 1, #self.Harbors[k].Routes do
             if self.Harbors[k].Routes[_index].OldHarbor == true then
                 StoreData = ModuleTrade.Global:GetStorehouseInformation(k)

--- a/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
@@ -317,8 +317,6 @@ function ModuleShipSalesment.Global:ControlHarbors()
                     end
                 end
 
-                local ResetTradeGoodsOnLeave = false
-
                 -- control trade routes
                 for i= 1, #v.Routes do
                     if v.Routes[i].State == QSB.ShipTraderState.Waiting then

--- a/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
@@ -40,12 +40,12 @@ function ModuleShipSalesment.Global:OnEvent(_ID, ...)
     if _ID == QSB.ScriptEvents.LoadscreenClosed then
         self.LoadscreenClosed = true;
     elseif  _ID == QSB.ScriptEvents.TradeShipLeft then
-        for _index = 1, #self.Harbors[args[1]].Routes do
-            if self.Harbors[args[1]].Routes[_index].OldHarbor == true then
-                StoreData = ModuleTrade.Global:GetStorehouseInformation(args[1])
+        for _index = 1, #self.Harbors[arg[1]].Routes do
+            if self.Harbors[arg[1]].Routes[_index].OldHarbor == true then
+                StoreData = ModuleTrade.Global:GetStorehouseInformation(arg[1])
                 for _NumberOfOffers = StoreData.OfferCount, 1 , -1 do
-                    local Offer = table.remove(self.Harbors[args[1]].AddedOffers, 1);
-                    API.RemoveTradeOffer(args[1], Offer);
+                    local Offer = table.remove(self.Harbors[arg[1]].AddedOffers, 1);
+                    API.RemoveTradeOffer(arg[1], Offer);
                 end
             end
         end

--- a/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
@@ -9,6 +9,7 @@ ModuleShipSalesment = {
     Global = {
         Data = {},
         Harbors = {},
+        LoudTrader = true,
     },
     Local = {
         Data = {},
@@ -39,6 +40,14 @@ end
 function ModuleShipSalesment.Global:OnEvent(_ID, ...)
     if _ID == QSB.ScriptEvents.LoadscreenClosed then
         self.LoadscreenClosed = true;
+    elseif _ID == QSB.ScriptEvents.TradeShipSpawned then
+        if ModuleShipSalesment.Global.LoudTrader then
+            Logic.ExecuteInLuaLocalState("LocalScriptCallback_QueueVoiceMessage(".. _PlayerID ..", 'TravelingSalesmanSpotted')");
+        end
+    elseif _ID == QSB.ScriptEvents.TradeShipArrived then
+        if ModuleShipSalesment.Global.LoudTrader then
+            Logic.ExecuteInLuaLocalState("LocalScriptCallback_QueueVoiceMessage(".. _PlayerID ..", 'TravelingSalesman')");
+        end
     elseif  _ID == QSB.ScriptEvents.TradeShipLeft then
         for _index = 1, #self.Harbors[arg[1]].Routes do
             if self.Harbors[arg[1]].Routes[_index].OldHarbor == true then
@@ -48,6 +57,13 @@ function ModuleShipSalesment.Global:OnEvent(_ID, ...)
                     API.RemoveTradeOffer(arg[1], Offer);
                 end
             end
+        end
+        if ModuleShipSalesment.Global.LoudTrader then
+            Logic.ExecuteInLuaLocalState("LocalScriptCallback_QueueVoiceMessage(".. _PlayerID ..", 'TravelingSalesman_Failure')");
+        end
+    elseif _ID == QSB.ScriptEvents.TradeShipDespawned then
+        if ModuleShipSalesment.Global.LoudTrader then
+            
         end
     end
 end

--- a/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
@@ -7,7 +7,6 @@ ModuleShipSalesment = {
     },
 
     Global = {
-        Conmpatibility = false,
         Data = {},
         Harbors = {},
     },
@@ -40,6 +39,16 @@ end
 function ModuleShipSalesment.Global:OnEvent(_ID, ...)
     if _ID == QSB.ScriptEvents.LoadscreenClosed then
         self.LoadscreenClosed = true;
+    else _ID == QSB.ScriptEvents.TradeShipLeft then
+        for _index = 1, #self.Harbors[k].Routes do
+            if self.Harbors[k].Routes[_index].OldHarbor == true then
+                StoreData = ModuleTrade.Global:GetStorehouseInformation(k)
+                for _NumberOfOffers = StoreData.OfferCount, 1 , -1 do
+                    local Offer = table.remove(self.Harbors[k].AddedOffers, 1);
+                    API.RemoveTradeOffer(k, Offer);
+                end
+            end
+        end
     end
 end
 
@@ -336,7 +345,6 @@ function ModuleShipSalesment.Global:ControlHarbors()
                         if v.Routes[i].Timer >= v.Routes[i].Duration then
                             self.Harbors[k].Routes[i].State = QSB.ShipTraderState.MovingOut;
                             self.Harbors[k].Routes[i].Timer = 0;
-                            ResetTradeGoodsOnLeave = self.Conmpatibility
                             self:SendShipLeftEvent(k, v.Routes[i], ShipID);
                             self:MoveShipOut(k, i);
                         end
@@ -349,16 +357,6 @@ function ModuleShipSalesment.Global:ControlHarbors()
                             self:DespawnShip(k, i);
                         end
                     end
-                end
-
-                -- reset offers
-                if self.Conmpatibility and ResetTradeGoodsOnLeave then
-                    self.Harbors[k].AddedOffers = {}
-                    local StoreData = ModuleTrade.Global:GetStorehouseInformation(k);
-                    for i= 1, #StoreData[1] do
-                        ModuleTrade.Global:RemoveTradeOfferByData(StoreData, i)
-                    end
-                    ResetTradeGoodsOnLeave = false
                 end
             end
         end

--- a/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
+++ b/qsb/lua/modules/QSB_3_TradeRoutes/source.lua
@@ -40,12 +40,12 @@ function ModuleShipSalesment.Global:OnEvent(_ID, ...)
     if _ID == QSB.ScriptEvents.LoadscreenClosed then
         self.LoadscreenClosed = true;
     elseif  _ID == QSB.ScriptEvents.TradeShipLeft then
-        for _index = 1, #self.Harbors[k].Routes do
-            if self.Harbors[k].Routes[_index].OldHarbor == true then
-                StoreData = ModuleTrade.Global:GetStorehouseInformation(k)
+        for _index = 1, #self.Harbors[args[1]].Routes do
+            if self.Harbors[args[1]].Routes[_index].OldHarbor == true then
+                StoreData = ModuleTrade.Global:GetStorehouseInformation(args[1])
                 for _NumberOfOffers = StoreData.OfferCount, 1 , -1 do
-                    local Offer = table.remove(self.Harbors[k].AddedOffers, 1);
-                    API.RemoveTradeOffer(k, Offer);
+                    local Offer = table.remove(self.Harbors[args[1]].AddedOffers, 1);
+                    API.RemoveTradeOffer(args[1], Offer);
                 end
             end
         end


### PR DESCRIPTION
Das Logging hat ein neues Level bekommen, nämlich 5; das wird durch geforcet und heißt "manuelLogging".

Ebenso wurde der Hafen angepasst, indem ein Event in der OnEvent-Funktion des Moduls erweitert hinzugefügt wurde.
Nebenbei wurde noch die Möglichkeit gegeben den Routen Namen zu geben. Das ist vorallem für Events und das Verändern von Angeboten momentan wichtig, da die über die Routen-Namen gehen.

Getestet ist es noch nicht, weshalb es auf jean branch gemerged wird.